### PR TITLE
Fix several links in pages.

### DIFF
--- a/hardware/index.md
+++ b/hardware/index.md
@@ -316,7 +316,7 @@ manufacture of attachments e.g. via 3D printing.
 
 [Schematic](./schematic)
 
-[Reference Design](./referencedesign)
+[Reference Design](./reference-design)
 
 [Nordic NRF51 datasheet](http://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.1.pdf)
 

--- a/hardware/index.md
+++ b/hardware/index.md
@@ -227,7 +227,7 @@ mode at any one time.
 | Edge Connector| [mechanical data](./mechanical.md)
 | Pitch | 1.27mm, 80 way double sided.
 | Pads| 5 pads, with 4mm holes
-| More Info | [here](../edgeconnector)
+| More Info | [here](/hardware/edgeconnector/)
 
 
 ## Power Supply
@@ -262,7 +262,7 @@ main computer.
 | RAM           | 4KB
 | Speed         | 16MHz
 | Debug capabilities | SWD
-| More Info | [here](../software/interface)
+| More Info | [here](/software/daplink-interface/)
 
 
 ## USB Communications
@@ -281,7 +281,7 @@ of application programs.
 | Speed         | 12Mbit/sec
 | USB classes supported | [Mass Storage Class (MSC)](https://en.wikipedia.org/wiki/USB_mass_storage_device_class)
 |    | [Communications Device Class (CDC)](https://en.wikipedia.org/wiki/USB_communications_device_class)
-| More Info | [here](../software/interface)
+| More Info | [here](/software/daplink-interface/)
 
 
 ## Debugging

--- a/hardware/powersupply.md
+++ b/hardware/powersupply.md
@@ -38,7 +38,7 @@ plugged into the edge connector.
 System LED will not light up when powered from battery)
 
 * All key facts can be independently verified and understood further by looking
-at the [schematic](./schematic.md) and refering to the appropriate chip data
+at the [schematic](/hardware/schematic/) and refering to the appropriate chip data
 sheets also listed on that page.
 
 
@@ -112,7 +112,7 @@ of over voltage protection, or proper regulation.
 
 ## Power Supply Architecture
 
-The [schematic](./schematic.md) shows the architecture of the power supply.
+The [schematic](/hardware/schematic/) shows the architecture of the power supply.
 Key points to note are that there are two BAT60A diodes, one from the 3.3V
 supply from the KL26 interface chip, and one from the external battery connector.
 Note that the 3V ring on the edge connector is V_TGT, which is the raw

--- a/hardware/powersupply.md
+++ b/hardware/powersupply.md
@@ -83,7 +83,7 @@ this might look like the micro:bit is not working, but it is.
 Because the nRF51822 is powered almost directly (there is only one BAT60 diode
 between the supply and the nRF51 power rails), a fully charged **LiPoly battery**
 that is specced to reach 4.2V **will be give greater than the 3.9V maximum that
-the nRF51822 can withstand** [see below](#Key Voltages)
+the nRF51822 can withstand** [see below](#key-voltages)
 
 Different types of batteries will provide different peak currents and behave
 differently when accidentally shorted. Because of this, the BBC

--- a/hardware/reference-design.md
+++ b/hardware/reference-design.md
@@ -41,7 +41,7 @@ programmer to program all your micro:bit based designs!
 features: 3xbuttons, 5x5 display, accelerometer, magnetometer)**
 * Released under the [SolderPad License 0.51](http://solderpad.org/licenses/SHL-0.51/) (based on Apache-2.0, but tailored
   towards Open Hardware)
-* Based on an [nRF5188 module](#Module Choice) for ease of use
+* Based on an [nRF5188 module](#module-choice) for ease of use
 * Separate programmer and debugger circuits so that you can strip back
 things that you don't need
 * Standard 2.54mm pitch connector for

--- a/hardware/reference-design.md
+++ b/hardware/reference-design.md
@@ -99,7 +99,7 @@ your board to flash it for you
 
 ## KL26 software
 
-As described on the [interface firmware](/software/interface) page, there is
+As described on the [interface firmware](/software/daplink-interface) page, there is
 a bootloader and a main interface program that needs to be flashed to the KL26Z.
 
 The hex file/image that contains both of these together can be found


### PR DESCRIPTION
The `/software/interface.md` file has been permalink to`/software/daplink-interface/`. The `software/index.md` links to this page correctly, but not the `reference-design.md ` page.