### PR TITLE
Remove MicroPi (C/C++ editor) from the micropython page.

### DIFF
--- a/software/micropython.md
+++ b/software/micropython.md
@@ -214,8 +214,6 @@ A couple of Python modules provide code and command line commands for
 Many people in the international Python community have contributed free-to-use
 resources via the [MicroPython / BBC micro:bit World Tour](https://microworldtour.github.io/).
 
-[MicroPi](https://github.com/Bottersnike/Micro-Pi)
-
 [Online python simulator](https://create.withcode.uk/)
 
 ## Documentation


### PR DESCRIPTION
MicroPi as it is a C/C++ editor written in Python, not a Python editor, so I've removed it from the micropython page.
We should probably have a page for C/C++ development with the DAL, in which case we should definitely put it back there.