### PR TITLE
Rephrase "lozenge" to "rounded rectangular"

### DIFF
--- a/accessories/making-accessories.md
+++ b/accessories/making-accessories.md
@@ -29,17 +29,19 @@ The edge connector on the <span class="V2">V2</span> board revision is backwards
 
 ## Battery Pads
 
-There are two lozenge shaped pads on the back of the micro:bit. These allow you to connect a battery holder via a mechanism other than the JST connector.
+There are two rounded rectangular pads on the back of the micro:bit. These allow you to connect a battery holder via a mechanism other than the JST connector.
 
-![Picture of the two lozenges](/docs/accessories/assets/making-accessories-d7c25.png)
+![Picture of the two rounded rectangular pads](/docs/accessories/assets/making-accessories-d7c25.png)
+
+The upper pad is 0V or GND and the lower pad is 3V.
 
 ### V2 revision
 
-In the <span class="v2">V2</span> board revision, the 3V lozenge is connected to the 3V ring on the edge connector.
+In the <span class="v2">V2</span> board revision, the 3V rounded rectangular pad is connected to the 3V ring on the edge connector.
 
-- If you make an accessory that uses the lozenges, it must be protected from reverse charging when the board is powered by USB, battery or edge connector.
-- You can now source power from the lozenges if you are making an accessory, as they are consistent with the power architecture of the edge connector.
+- If you make an accessory that uses the rounded rectangular pads, it must be protected from reverse charging when the board is powered by USB, battery or edge connector.
+- You can now source power from the rounded rectangular pads if you are making an accessory, as they are consistent with the power architecture of the edge connector.
 
-Due to the addition of a speaker, current accessories that use the lozenges to power the micro:bit will no longer fit.
+Due to the addition of a speaker, current accessories that use the rounded rectangular pads to power the micro:bit will no longer fit.
 
 

--- a/hardware/powersupply.md
+++ b/hardware/powersupply.md
@@ -16,7 +16,7 @@ Power to the micro:bit may be provided via:
 - USB connection via the interface chip (which has an on-board regulator)
 - A battery plugged into the JST connector.
 - The 3V and GND pins on the Edge Connector
-- The two lozenge shaped pads on the rear right of the board
+- The two [rounded rectangular pads](/docs/accessories/assets/making-accessories-d7c25.png) on the rear right of the board
 
 Power from the micro:bit can be provided by the 3V and GND pins to small external circuits.
 
@@ -83,9 +83,13 @@ There is further information about the [battery connection and use](https://supp
 ### 3V Ring Powering
 
 The micro:bit may be powered from the 3V/GND rings on the edge connector.
-There are also two lozenge shaped pads on the far right of the back of the PCB that can be used to supply power (e.g. solderable pads for a 2xAAA holder that has wires or pins at one edge). [The topmost lozenge is 0V and the bottom most lozenge is 3V](../../accessories/making-accessories/#battery-pads).
+There are also two [rounded rectangular pads](/docs/accessories/assets/making-accessories-d7c25.png) on the far right of the back of the PCB that can be used to supply power (e.g. solderable pads for a 2xAAA holder that has wires or pins at one edge).
 
-When powering from the 3V ring or the lozenge on the PCB, you should take appropriate best practice precautions:
+![Picture of the two rounded rectangular pads](/docs/accessories/assets/making-accessories-d7c25.png)
+
+The upper pad is 0V or GND and the lower pad is 3V.
+
+When powering from the 3V ring or the rounded rectangular pads on the PCB, you should take appropriate best practice precautions:
 
 1. Fit an external protection diode (preferably with a low Vf rating) to prevent damage due to the power supply being connected the wrong way round.
 
@@ -95,7 +99,7 @@ When powering from the 3V ring or the lozenge on the PCB, you should take approp
 
 The [schematic](/hardware/schematic/) shows the architecture of the power supply.
 Key points to note are that there are two BAT60A diodes, one from the 3.3V supply from the KL26/27 interface chip, and one from the external battery connector.
-Note that the 3V ring on the edge connector is V_TGT, which is the raw supply provided to all on-board chips, so this is why extra care should be taken when connecting directly to the 3V ring or the 3V lozenge.
+Note that the 3V ring on the edge connector is V_TGT, which is the raw supply provided to all on-board chips, so this is why extra care should be taken when connecting directly to the 3V ring or the 3V [rounded rectangular pad](/docs/accessories/assets/making-accessories-d7c25.png).
 
 The BAT60A devices have a low Vf rating, you can read about this in the [BAT60A datasheet](http://www.infineon.com/dgdl/Infineon-BAT60ASERIES-DS-v01_01-en.pdf?fileId=db3a304313d846880113def70c9304a9)
 

--- a/latest-revision/latest-revision-accessories.md
+++ b/latest-revision/latest-revision-accessories.md
@@ -82,9 +82,11 @@ Whereas on previous revisions, the I2C bus was shared between the motion sensor 
 
 ### Power
 
-The micro:bit can now be powered from the two lozenge shaped pads on the rear of the board and the 3V/GND pins.
+The micro:bit can now be powered from the two rounded rectangular pads on the rear of the board and the 3V/GND pins.
 
-If you use the lozenge pads, you must diode (or otherwise) protect themselves from the micro:bit having power via another source. This was still necessary on the previous revision when the board was powered from battery, but is now true for USB and edge-connector power also.
+![Picture of the two rounded rectangular pads](/docs/accessories/assets/making-accessories-d7c25.png)
+
+If you use the rounded rectangular pads, you must diode (or otherwise) protect themselves from the micro:bit having power via another source. This was still necessary on the previous revision when the board was powered from battery, but is now true for USB and edge-connector power also.
 
 The nRF52 supplies 300mA to drive the board.   110mA is reserved for powering on-board components. **190mA** is then available for accessories.
 


### PR DESCRIPTION
Getting this one out of the way before I start rephrasing.

* Change "lozenge shaped pads" to "rounded rectangular pads" as discussed in #170
* Add power pads picture to Latest Revision Accessories
* Link "rounded rectangular pads" text to the picture where it's not already embedded