### PR TITLE
Update edgeconnector.md: correct SVG broken links

### DIFF
--- a/hardware/edgeconnector.md
+++ b/hardware/edgeconnector.md
@@ -32,7 +32,7 @@ Pin 9 is no longer jointly shared with the LED display, but Pin 8 and Pin 9 can 
 
 | V2   | v1
 | ---- | ---- 
-| ![edge connector V2](/docs/hardware/assets/edge-connector-2.svg) | ![edge connector v1](/docs/hardware/assets/edge_connector.svg)
+| ![edge connector V2](/hardware/assets/edge-connector-2.svg) | ![edge connector v1](/hardware/assets/edge_connector.svg)
 
 ### microbit.pinout.xyz
 


### PR DESCRIPTION
correct SVG broken links of v1 and v2 edge connectors
before pointing to /docs/hardware/assets/*.svg,
now pointing to /hardware/assets/*.svg