### PR TITLE
Rephrasing software section

### DIFF
--- a/software/bitio.md
+++ b/software/bitio.md
@@ -17,7 +17,7 @@ bitio (pronounced bitty-o) is a micro:bit I/O library for Python. It allows you 
 
 ## Why would you use bitio?
 
-The library is useful if you want to use the micro:bit as an input or an output device for other programs, e.g. for Minecraft. Tilt your micro:bit, and something happens in the Minecraft world. It can be used for anything though, where you want to use the input and output devices on the micro:bit inside a Python program on a bigger computer.
+bitio is useful if you want to use the micro:bit as an input or output device for other programs, e.g. for Minecraft: Tilt your micro:bit, and something happens in the Minecraft world. It can be used anywhere you might want to use the input and output devices on the micro:bit inside a Python program on a bigger computer.
 
 ## Getting Started
 

--- a/software/hex-format.md
+++ b/software/hex-format.md
@@ -15,48 +15,52 @@ review-with: carlospa
 
 The .hex file is in [intel-hex format](https://en.wikipedia.org/wiki/Intel_HEX). Intel hex consists of records of data, with the address in memory to store the data at the start. All data is hex-ascii encoded. All lines start with a : character. All lines end with a checksum byte that can be used to verify the integrity of the data.
 
-A micro:bit .hex file usually starts writing data to the same fixed location in memory, so depending on the toolchain, we might expect the first line of the file to start like this:
+A micro:bit .hex file usually starts writing data to the same fixed location in memory. Depending on the toolchain, we might expect the first line of the file to start like this:
 
 :020000040000FA
 
 ## Universal Hex files
 
-The latest board revision introduces a superset of the Intel-Hex format that enables compatibility across processor variants. A Universal Hex is a file that contains the binary data for both micro:bit <span class="v1">V1</span> and micro:bit <span class="v2">V2</span>, in a format that DAPLink can process to only write to memory the data relevant to its micro:bit board.
+The latest board revision introduces a superset of the Intel-Hex format that enables compatibility across processor variants. A Universal Hex is a file that contains the binary data for both micro:bit <span class="v1">v1</span> and micro:bit <span class="v2">V2</span>, in a format that DAPLink can process and write to memory only the data relevant to its micro:bit board.
 
-A **Universal Hex** hex file will work on a V1 or V2 board.
-A clear indication that you are working with this format is that a compiled .hex file will be ~1.8Mb as opposed to ~700Kb in size.
+A **Universal Hex** hex file will work on a v1 or V2 board.
 
-A [Universal Hex JavaScript Library](https://github.com/microbit-foundation/microbit-universal-hex) has been written to implement the format and associated detailed [specification of the Universal Hex format](https://github.com/microbit-foundation/universal-hex/).
+A clear indication that you are working with this format is that the compiled .hex file will be ~1.8Mb instead of ~700Kb in size.
+
+The following resources will help you implement **Universal Hex** support in your application:
+
+* [Universal Hex JavaScript Library](https://github.com/microbit-foundation/microbit-universal-hex) 
+* [Detailed specification of the Universal Hex format](https://github.com/microbit-foundation/universal-hex/).
 
 ### Cross device compatibility
 
-The Universal Hex format has been developed to ensure the best experience for users when moving between board variants. If a V1 only .hex is detected on a V2 board it will throw an error, but a V2 only hex will fail silently on a V1. This is very confusing to users and should be avoided.
+Including *both* .hex formats within a Universal Hex ensures the best experience for users when moving between board variants. If a v1 only .hex is detected on a V2 board it will throw an error, but a V2 only hex will fail silently on a v1. This is confusing to users and should be avoided.
 
-There may be cases where it is not possible to support both boards, for example an accessory that is designed only to target the V2 board variant. In these cases, to ensure the best user experience when flashing a hex file to any board variant, the file should always include an error message to signify board incompatibility to the user.
+There may be cases where it is not possible to support both boards, for example an accessory that targets only the V2 board variant. In these cases, to ensure the best user experience when flashing a hex file to any board variant, the file should always include an error message to signify board incompatibility to the user.
 
-We have created a [standalone error hex](/docs/software/assets/stand-alone-error-v1.hex) that can be combined with a V2 only hex to produce a Hex that will work on a V2 board, but error if used on a V1.
+We have created a [standalone error hex](/docs/software/assets/stand-alone-error-v1.hex) that can be combined with a V2 only hex to produce a Hex that will work on a V2 board, but error if used on a v1.
 
 {% include alert-info.html content="We are currently working on a web based and CLI tool to generate Universal Hex files and will publish information on usage here when this is ready. In the meantime, please [get in contact](mailto:support@microbit.org) if you require further information" %}
 
 [Download standalone error hex](/docs/software/assets/stand-alone-error-v1.hex){: .btn.sm-btn download}
 
-This example shows the worst, best and acceptable (when support for V1 is impossible) cases for users. The best case is to provide a Universal Hex that supports all board variants.
+This example shows the worst, best and acceptable (when support for v1 is impossible) cases for users. The best case is to provide a Universal Hex that supports all board variants.
 ![Universal Hex error 1](/docs/software/assets/hex-compatibility-errors.png)
 
-These examples show the process of creating a Universal Hex. A V1 and V2 hex can be combined to produce a Universal Hex. If you can only support a V2 board, the standalone error can be combined with a V2 hex to produce a hex that will fail with an error on a V1 board, rather than failing silently.
+These examples show the process of creating a Universal Hex. A v1 and V2 hex can be combined to produce a Universal Hex. If you can only support a V2 board, the standalone error can be combined with a V2 hex to produce a hex that will fail with an error on a v1 board, rather than failing silently.
 
-|Universal Hex format                                                 |V2 only Hex format                               |
+|Universal Hex format                                       |V2 only Hex format                                         |
 |-----------------------------------------------------------|-----------------------------------------------------------|
 | ![Universal Hex error 2](/docs/software/assets/uhex2.png) | ![Universal Hex error 3](/docs/software/assets/uhex1.png) |
 
-If you are building .hex files for both board variants, you will need to use the respective toolchains for the DAL<span class="v1">V1</span> and CODAL<span class="v2">V2</span>. See more information on the [micro:bit runtime](../runtime/).
+If you are building .hex files for both board variants, you will need to use the respective toolchains for the DAL<span class="v1">v1</span> and CODAL<span class="v2">V2</span>. See more information on the [micro:bit runtime](../runtime/).
 
 ## Micropython
 
 See the [Micropython Hex file reference](https://microbit-micropython.readthedocs.io/en/latest/devguide/hexformat.html) for up to date information.
 
-MicroPython builds take a firmware.hex image (the MicroPython pre-compiled image) and appends your script to the end of it, in a fixed 8K region at a known address. When MicroPythons starts to run on the micro:bit, it looks for a signature at this fixed location, and uses that to determine whether to run the script, or drop directly to the REPL prompt.
+MicroPython builds take a "firmware.hex" image (the MicroPython pre-compiled image) and appends your script to the end of it, in a fixed 8K region at a known address. When MicroPythons starts to run on the micro:bit, it looks for a signature at this fixed location, and uses that to determine whether to run the script, or drop directly to the REPL prompt.
 
 ## Microsoft MakeCode Editor
 
-Hex files generated by the [MakeCode Editor](https://makecode.microbit.org) have embedded meta-data inside the .hex file. This is a [JSON encoded blob with various data about the script](https://github.com/Microsoft/pxt/blob/437f53ca6311335c7f3f75a062ec1079b4e7806a/docs/source-embedding.md), and also the source code program. This may be compressed, and it is stored inside the flash memory of the micro:bit (but only if space is available in the flash memory). But it is always inside the .hex file. This embedded source code program ensures that when you drag and drop the .hex file onto the originating editor, it can recover the source program again.
+Hex files generated by the [MakeCode Editor](https://makecode.microbit.org) include the source code of the program in addition to embedded metadata. This metadata comprises a [JSON encoded blob with information about the script](https://github.com/Microsoft/pxt/blob/437f53ca6311335c7f3f75a062ec1079b4e7806a/docs/source-embedding.md). Both the metadata and source code may be compressed and, space permitting, are stored inside the flash memory of the micro:bit. When you drag and drop a MakeCode .hex file onto the originating editor it can recover the source code, allowing the program to be modified and saved back to a .hex.

--- a/software/in_browser_compiler.md
+++ b/software/in_browser_compiler.md
@@ -12,13 +12,14 @@ lang: en
 ## Overview
 
 There are a number of different code editors for the micro:bit.
+
 Of the available editors; [MakeCode](https://makecode.microbit.org) and [Python](https://python.microbit.org) have an in-browser compiler. This means that when you hit the **Download** button to translate your code into a language supported by the micro:bit, all of the hard work takes place inside your web browser.
 
 You can also use MicroPython offline by installing the [Mu editor](https://codewith.mu) on your computer.
 
-The in-browser build process is useful, because you are not dependent on an internet connection in order to code and innovate with your micro:bit - once you have the web page open and the editor is cached on your computer, you can work independently of internet access.
+The in-browser build process is useful, because you are not dependent on an internet connection in order to code and innovate with your micro:bit. Once you have the web page open and the editor is cached on your computer, you can work independently of internet access.
 
-By being web based, these editors allow you to write code for the micro:bit without needing to install any special software on your computer, which is especially important if working in a previously unused classroom, or on a public computer.
+Since they are web based, these editors allow you to write code for the micro:bit without needing to install any special software on your computer. This is especially important if you are working in a previously unused classroom, or on a public computer.
 
 ## How it Works
 
@@ -32,7 +33,7 @@ The above diagram shows an example of how blocks code is converted into a .hex f
 
 1c. The Arm machine code instructions are 'linked' with the Lancaster University runtime code, [the DAL](/software/runtime) and converted into an [Intel-HEX file format](/software/hex-format). This is done by ensuring that the in-browser-compiler knows the entry points of key functions that it needs to be able to call out into.
 
-2. You accept the download of the .hex file, which is stored in the filing system on your computer.
+2. You accept the download of the .hex file, which is saved to your computer.
 
 3. Download/Flash the .hex file onto the MICROBIT drive, and the interface processor on the micro:bit copies it into the flash memory inside the application processor. Your code now runs.
 


### PR DESCRIPTION
Sweeping up more changes from #170:

* Minor changes to `bitio.md`
* Quite significant changes to `hex-format.md` including some- hopefully correct- re-wording for clarity and a replacement of "V1" with "v1" which seems to be the standard- is this correct?
* Minor changes to `in_browser_compiler.md`
* Work in progress!