### PR TITLE
Re-phrase making-accessories to be more direct

### DIFF
--- a/accessories/making-accessories.md
+++ b/accessories/making-accessories.md
@@ -14,7 +14,7 @@ A [list of available accessories](https://microbit.org/buy/accessories/) is main
 
 ## Using the Edge Connector
 
-The micro:bit [card edge connector](/hardware/edgeconnector), commonly referred to as the 'edge connector' or the 'pins', is compatible with a standard edge connector socket.
+The micro:bit [card edge connector](/hardware/edgeconnector), commonly referred to as the 'edge connector' or the 'pins', is compatible with a standard 1.27mm, 2x40 edge connector socket.
 
 Where possible your accessory design should implement this socket, making it simple for your users to plug in and remove the micro:bit board.
 

--- a/accessories/making-accessories.md
+++ b/accessories/making-accessories.md
@@ -14,18 +14,18 @@ A [list of available accessories](https://microbit.org/buy/accessories/) is main
 
 ## Using the Edge Connector
 
-The micro:bit card edge connector, commonly referred to as the 'edge connector' or the 'pins' makes accessory design easy.
+The micro:bit [card edge connector](/hardware/edgeconnector), commonly referred to as the 'edge connector' or the 'pins', is compatible with a standard edge connector socket.
 
-Many micro:bit accessories are designed to use an edge connector socket, so it is simple to plug in and remove the board.
+Where possible your accessory design should implement this socket, making it simple for your users to plug in and remove the micro:bit board.
 
-There are limitations to the current that can be drawn from the micro:bit, and accessories must be designed carefully to ensure they do not damage the micro:bit, or that the micro:bit cannot damage them.
+There are [limitations to the current that can be drawn from the micro:bit](/hardware/powersupply), accessories must be designed carefully to ensure they do not damage the micro:bit, or that the micro:bit cannot damage them.
+
+- [micro:bit edge connector and pinout](/hardware/edgeconnector)
+- [powering accessories from the micro:bit](/hardware/powersupply)
 
 ### V2 revision
 
 The edge connector on the <span class="V2">V2</span> board revision is backwards compatible with the <span class="v1">V1</span> edge connector, but has additional dedicated pins.
-
-- Details of the [edge connector and pinout](/hardware/edgeconnector)
-- Details about [powering things from the board](/hardware/powersupply)
 
 ## Battery Pads
 


### PR DESCRIPTION
The "Making Accessories" page suffers from a case of the waffles;

- `makes accessory design easy` - not really! 😆 
- `Many micro:bit accessories` - how many? 
- `are designed to use an edge connector` - What proportion that were "designed to" use the edge connector actually successfully pull it off?
- some links are erroneously under the "V2" title when they relate to both versions

I have attempted to reword this page to be more direct, making truthful statements that are useful to a PCB designer and avoiding unquantifiable, fluffy statements.

One key thing that's missing from documentation around the Edge Connector (unless I missed it) is any direct link to a suitable connector part. Is there a particular reason why the Foundation is not linking to suppliers? Is there a preferred supplier that could be linked to?

Hosting and linking to a datasheet for a compatible part might be a good compromise if all else fails. EG: Here's 4ucon's connector I found on Coolcomponents - http://www.4uconnector.com/online/object/4udrawing/10156.pdf