### PR TITLE
Stop creating Github issues for link failures

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -15,11 +15,5 @@ jobs:
       with:
         # Only check external links 
         args: -v -x "^[^:]+$|^https://uk\.farnell\.com/|^https://www\.kitronik\.co\.uk/pdf/bbc_microbit_mechanical_datasheet_V2\.pdf|^https://www\.lancaster\.ac\.uk/news/articles/2016/lancaster-university-helps-bbc-get-kids-coding/$" -d . -t 30 -r *
-    - name: Create Issue From File
-      uses: peter-evans/create-issue-from-file@v2
-      with:
-        title: Link Checker Report
-        content-filepath: ./link-checker/out.md
-        labels: links
     - name: Fail if there were link errors
       run: exit ${{ steps.lc.outputs.exit_code }}


### PR DESCRIPTION
failure reports come via email anyway, so forwarding these emails to our helpdesk would be an easier process to manage day to day

Or we could use something like https://github.com/marketplace/actions/send-email to send the error report