### PR TITLE
rename newsletter

### DIFF
--- a/community/developer-news.md
+++ b/community/developer-news.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 order:
-title: Developer news
+title: Developer and ecosystem news
 heading: Join the micro:bit developer conversation
 description: Sign up to the newsletter and view recent news
 permalink: /community/news/
@@ -9,12 +9,12 @@ ref: news
 lang: en
 ---
 
-## The DAL, Editors and Devices newsletter
+## Developer and ecosystem news
 
-In addition to our regular [Micro:bit Educational Foundation newsletter](https://mailchi.mp/microbit/newsletter), our [DAL, Editors and Devices](https://microbit.us14.list-manage.com/subscribe?u=e1c30f24b90ff3d70275cfff2&id=25403c7650) newsletter is a low volume digest on the technical aspects of micro:bit. The details you provide are processed in accordance with The Foundation's [privacy policy](https://microbit.org/privacy/).
+In addition to our regular [Micro:bit Educational Foundation newsletter](https://mailchi.mp/microbit/newsletter), our [Developer and ecosystem](https://microbit.us14.list-manage.com/subscribe?u=e1c30f24b90ff3d70275cfff2&id=25403c7650) newsletter is a low volume digest on the technical aspects of micro:bit. The details you provide are processed in accordance with The Foundation's [privacy policy](https://microbit.org/privacy/).
 
 <div style="text-align: center;">
-<a href="https://microbit.us14.list-manage.com/subscribe?u=e1c30f24b90ff3d70275cfff2&id=25403c7650" class="btn sm-btn" role="button" style="margin-bottom: 2rem;">Subscribe to DAL, Editors and Devices</a>
+<a href="https://microbit.us14.list-manage.com/subscribe?u=e1c30f24b90ff3d70275cfff2&id=25403c7650" class="btn sm-btn" role="button" style="margin-bottom: 2rem;">Subscribe to Developer and ecosystem news</a>
 </div>
 
 ## News archive


### PR DESCRIPTION
We renamed our newsletter to be 'developer and ecosystem' news back when we launched the V2.00 device to reflect the audience. We should update the website accordingly