### PR TITLE
Re-order sections of the overview for the hardware

### DIFF
--- a/hardware/index.md
+++ b/hardware/index.md
@@ -27,7 +27,7 @@ Two key pieces of information to help understand the internals of the micro:bit 
 - The [schematics](./schematic), which shows the detailed component data and connectivity of the device.
 
 - The [reference design](./reference-design), which is a complete module design of a compatible micro:bit, and is designed to be a starting point for anyone interested in understanding the micro:bit or designing their own variant.
-- 
+
 ![Board overview 2.2](/docs/hardware/assets/microbit-overview-2-2.png)
 
 ## Hardware block diagram

--- a/hardware/index.md
+++ b/hardware/index.md
@@ -16,15 +16,9 @@ lang: en
 * TOC
 {:toc}
 
-![Board overview 2.2](/docs/hardware/assets/microbit-overview-2-2.png)
+## About the BBC micro:bit
 
-## Hardware block diagram
-
-![2.2 block](/docs/hardware/assets/v2-2-block.svg)
-
-## Getting Started With the micro:bit Hardware
-
-The micro:bit is a Single Board Computer (SBC) that contains an application processor with a variety of on-chip peripherals. Other peripherals are connected to this chip.
+The micro:bit is an easily programmable Single Board Computer (SBC) that contains an application processor with a variety of on-chip peripherals. Other peripherals are connected to this chip.
 
 An interface processor is connected to the application processor and manages communications via the USB interface, including the drag-and-drop code flashing process. The interface processor does not connect to any of the micro:bit peripherals.
 
@@ -33,6 +27,13 @@ Two key pieces of information to help understand the internals of the micro:bit 
 - The [schematics](./schematic), which shows the detailed component data and connectivity of the device.
 
 - The [reference design](./reference-design), which is a complete module design of a compatible micro:bit, and is designed to be a starting point for anyone interested in understanding the micro:bit or designing their own variant.
+- 
+![Board overview 2.2](/docs/hardware/assets/microbit-overview-2-2.png)
+
+## Hardware block diagram
+
+![2.2 block](/docs/hardware/assets/v2-2-block.svg)
+
 
 ## Hardware Description
 


### PR DESCRIPTION
We'd like to give some context before the pictures of the devices, especially helpful when printing the document.