### PR TITLE
Add some information about the Bluetooth extension in MakeCode

### DIFF
--- a/bluetooth/index.md
+++ b/bluetooth/index.md
@@ -99,6 +99,9 @@ As an example, the tools at [ML Machine](ml-machine.org) have been built with th
 
 Note: on micro:bit V1, there is very limited memory available when also using the Bluetooth extension.
 
+Here is an example of how to add and use the Bluetooth extension in MakeCode
+![adding makecode bluetooth extension](/docs/bluetooth/assets/add_bluetooth_extension.gif)
+
 ## Apps
 
 - [Android App](https://play.google.com/store/apps/details?id=com.samsung.microbit) facilitates [pairing and flashing programs to the micro:bit](https://support.microbit.org/en/support/solutions/articles/19000051025-pairing-and-flashing-code-via-bluetooth)

--- a/bluetooth/index.md
+++ b/bluetooth/index.md
@@ -85,9 +85,19 @@ We are seeking collaborators to help us define the new profile elements that exp
 
 ## Bluetooth and the micro:bit software
 
-The [DAL/C++ reference documentation](https://lancaster-university.github.io/microbit-docs/ble/profile/#reference-documentation) lists the adopted and custom features available within the profile. [MakeCode](https://makecode.microbit.org/reference/bluetooth) contains a set of blocks to make use of the various micro:bit services.
+The [DAL/C++ reference documentation](https://lancaster-university.github.io/microbit-docs/ble/profile/#reference-documentation) lists the adopted and custom features available within the profile. 
 
 The processor also has several non-bluetooth, proprietary modes of operation upon which the micro:bit radio protocol is based. This protocol works only between micro:bits and is defined as 'Micro:bit Radio' in the DAL and 'radio' in MakeCode, MicroPython, and Mbed C++.
+
+### Bluetooth in MakeCode
+
+There is a ["Bluetooth" extension](https://makecode.microbit.org/reference/bluetooth) in Microsoft MakeCode that can be used to instantiate individual services from the micro:bit Bluetooth profile, as well as events for connection and disconnection. It is mutually exclusive to the "Radio" extension.
+
+These services can then be used in conjunction with things like [the micro:bit web components](https://github.com/thegecko/microbit-web-components) to interact with the micro:bit over Bluetooth.
+
+As an example, the tools at [ML Machine](ml-machine.org) have been built with this extension in MakeCode.
+
+Note: on micro:bit V1, there is very limited memory available when also using the Bluetooth extension.
 
 ## Apps
 


### PR DESCRIPTION
We don't have this information on microbit.org, and really the main users of the Bluetooth extension are people building other tools with the micro:bit, or advanced developers. I think it belongs on the tech site in the first instance.