### PR TITLE
Update schematic links for V2.00 and V2.2x

### DIFF
--- a/hardware/schematic.md
+++ b/hardware/schematic.md
@@ -27,7 +27,9 @@ If you're looking to make something of your own based on the micro:bit, you migh
 
 - [V1.3](https://github.com/bbcmicrobit/hardware/blob/master/V1.3B/SCH_BBC-Microbit_V1.3B.pdf)
 - [V1.5](https://github.com/bbcmicrobit/hardware/blob/master/V1.5/SCH_BBC-Microbit_V1.5.PDF)
-- [V2](https://github.com/microbit-foundation/microbit-v2-hardware/blob/main/V2/MicroBit_V2.0.0_S_schematic.PDF)
+- [V2.00](https://github.com/microbit-foundation/microbit-v2-hardware/blob/main/V2.00/MicroBit_V2.0.0_S_schematic.PDF)
+- [V2.2x](https://github.com/microbit-foundation/microbit-v2-hardware/blob/main/V2.21/MicroBit_V2.2.1_nRF52820%20schematic.PDF)
+
 
 ## V2 pinmap
 


### PR DESCRIPTION
As we added the V2.21 schematic we moved the location of the V2 version (to include the minor version number). This fixes the broken link.