### PR TITLE
Update schematic.md - TP21 is SDA

### DIFF
--- a/hardware/schematic.md
+++ b/hardware/schematic.md
@@ -182,7 +182,7 @@ TP8 | USB D-
 TP17 | Access to Pin 1 on Battery connector
 TP19 | Access to VBUS line on USB Connector
 TP20 | Access for debugging internal I2C bus - SCL
-TP21 | Access for debugging internal I2C bus - SCL
+TP21 | Access for debugging internal I2C bus - SDA
 TP9 | VREG - [Actually the power rounded rectangular pad](../../accessories/making-accessories/#battery-pads)
 TP10 | GND - [Actually the GND rounded rectangular pad](../../accessories/making-accessories/#battery-pads)
  


### PR DESCRIPTION
Arising from https://support.microbit.org/a/tickets/75360 (private)
TP20 and TP21 both say SCL. Change TP21 to SDA.
