### PR TITLE
Change CODAL to DAL in software-overview.svg for mb v1

### DIFF
--- a/software/assets/software-overview.svg
+++ b/software/assets/software-overview.svg
@@ -64,7 +64,7 @@
        x="1032.5px"
        y="2603.5px"
        style="font-family:'GTWalsheim-Bold', 'GT Walsheim', sans-serif;font-weight:600;font-size:250px;fill:white;"
-       id="text4161">CODAL</text>
+       id="text4161">DAL</text>
 <text
        x="1032.5px"
        y="2803.5px"


### PR DESCRIPTION
The Image for V1 shows "CODAL". I think it should be "DAL" there: https://tech.microbit.org/software/runtime/

![image](https://github.com/microbit-foundation/dev-docs/assets/3764089/d878e254-4c47-4cfd-9af8-9f747816a6f8)
