### PR TITLE
Hardware Schematic: update nRF52 and nRF51 datasheet links

### DIFF
--- a/hardware/schematic.md
+++ b/hardware/schematic.md
@@ -209,9 +209,9 @@ TP5 | VREG - additional VREG, this is connected to TP9
 
 - [KL26 datasheet](http://www.nxp.com/webapp/search.partparamdetail.framework?PART_NUMBER=MKL26Z128VFM4)
 
-- [nRF52833 datasheet](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrf52%2Fstruct%2Fnrf52833.html&cp=3_1)
+- [nRF52833 datasheet](https://www.nordicsemi.com/Products/nRF52833)
 
-- [nRF51822 datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF51822)
+- [nRF51822 datasheet](https://www.nordicsemi.com/Products/nRF51822)
 
 - [LSM303AGR datasheet](https://www.st.com/resource/en/datasheet/lsm303agr.pdf)
 


### PR DESCRIPTION
- nRF52833 link led to "Not Found" (see screenshot below) and was corrected.
- nRF51822 link working but outdated, and was simplified.


<img width="1010" height="878" alt="image" src="https://github.com/user-attachments/assets/862cd851-882a-4a60-8ff9-cfb57e06a0c0" />
